### PR TITLE
Add util for pattern recognition in filenames

### DIFF
--- a/lib/utils.py
+++ b/lib/utils.py
@@ -6,7 +6,6 @@ from datetime import datetime
 
 from transformers import AutoTokenizer, AutoModelForCausalLM
 from huggingface_hub import hf_hub_download, HfApi
-from datasets import load_dataset
 import requests
 
 
@@ -104,3 +103,63 @@ def download_pretrained_model_from_hf(model: str) -> T.Tuple[T.Any, T.Any]:
     tokenizer = AutoTokenizer.from_pretrained(model)
     model = AutoModelForCausalLM.from_pretrained(model)
     return tokenizer, model
+
+
+def filename_from_atoms(dataset: str, category: str, stage: str, timestamp: T.Optional[str] = None) -> str:
+    """
+    Returns a dataset filename from information like dataset, category, and stage along the chain
+    of qa, qae, qaev, qaeve. Information is underscore delimited. Timestamped to the microsecond.
+
+    Example usage:
+        filename_from_atoms(
+            dataset="mmlu",
+            category="econometrics",
+            "stage"="qae",
+        )
+    """
+    
+    if any("_" in s for s in [dataset, category, stage]):
+        raise ValueError("Don't use underscores in dataset, category, or stage for filename.")
+
+    timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f") if timestamp is None else timestamp
+    return f"{dataset}_{category}_{stage}_{timestamp}.json"
+
+
+def atoms_from_filename(filename: str) -> T.Tuple[str, str, str, str]:
+    """
+    Returns the dataset, category, stage, and timestamp of the filename.
+    """
+
+    path = Path(filename)
+    if path.suffix != ".json":
+        raise ValueError("Must use json file.")
+
+    atoms = path.stem.split("_")
+
+    if len(atoms) != 4:
+        raise ValueError(
+            "Expected 4 atoms in the filename (dataset, category, stage, timestamp),"
+            f"but found {len(atoms)}. Atoms are underscore delimited."
+        )
+
+    return tuple(atoms)
+
+
+def next_filename_in_chain(filename: str) -> str:
+    """
+    Returns the full filename of the next stage of the qa, qae, qaev, qaeve chain.
+
+    Uses the same timestamp as the previous stage to keep same datasets organized.
+    """
+
+    next_stage_dict = {"qa": "qae", "qae": "qaev", "qaev": "qaeve"}
+
+    dataset, category, stage, timestamp = atoms_from_filename(filename)
+
+    if stage not in next_stage_dict:
+        raise ValueError(f"Stage not recognized: {stage}. Known stages are {next_stage_dict.keys()}. Note that qaeve is the final stage and cannot be chained further.")
+
+    next_stage = next_stage_dict[stage]
+
+    return filename_from_atoms(dataset, category, next_stage, timestamp)
+

--- a/lib/utils.py
+++ b/lib/utils.py
@@ -105,10 +105,16 @@ def download_pretrained_model_from_hf(model: str) -> T.Tuple[T.Any, T.Any]:
     return tokenizer, model
 
 
-def filename_from_atoms(dataset: str, category: str, stage: str, timestamp: T.Optional[str] = None) -> str:
+def filename_from_atoms(
+        dataset: str, category: str, stage: str, deciever_model: T.Optional[str] = "anyModel", 
+        supervisor_model: T.Optional[str] = "anyModel", timestamp: T.Optional[str] = None
+        )-> str:
     """
     Returns a dataset filename from information like dataset, category, and stage along the chain
     of qa, qae, qaev, qaeve. Information is underscore delimited. Timestamped to the microsecond.
+
+    Additionally, if deciever model or supervisor model are yet to be specified, it is considered
+    to be "anyModel". 
 
     Example usage:
         filename_from_atoms(
@@ -118,16 +124,22 @@ def filename_from_atoms(dataset: str, category: str, stage: str, timestamp: T.Op
         )
     """
     
-    if any("_" in s for s in [dataset, category, stage]):
+    if any("_" in s for s in [dataset, category, stage, deciever_model, supervisor_model]):
         raise ValueError("Don't use underscores in dataset, category, or stage for filename.")
+    
+    if deciever_model=="anyModel" and (stage=="qae" or stage == "qaev" or stage == "qaeve"):
+        raise ValueError("qae, qaev, and qaeve datasets must specify 'deciever_model'")
+    
+    if supervisor_model=="anyModel" and (stage == "qaev" or stage == "qaeve"):
+        raise ValueError("qaev and qaeve datasets must specify 'supervisor_model'")
 
     timestamp = datetime.now().strftime("%Y-%m-%d-%H-%M-%S-%f") if timestamp is None else timestamp
-    return f"{dataset}_{category}_{stage}_{timestamp}.json"
+    return f"{dataset}_{category}_{stage}_{deciever_model}_{supervisor_model}_{timestamp}.json"
 
 
-def atoms_from_filename(filename: str) -> T.Tuple[str, str, str, str]:
+def atoms_from_filename(filename: str) -> T.Tuple[str, str, str, str, str, str]:
     """
-    Returns the dataset, category, stage, and timestamp of the filename.
+    Returns the dataset, category, stage, deciever model, supervisor model, and timestamp of the filename.
     """
 
     path = Path(filename)
@@ -136,16 +148,16 @@ def atoms_from_filename(filename: str) -> T.Tuple[str, str, str, str]:
 
     atoms = path.stem.split("_")
 
-    if len(atoms) != 4:
+    if len(atoms) != 6:
         raise ValueError(
-            "Expected 4 atoms in the filename (dataset, category, stage, timestamp),"
+            "Expected 6 atoms in the filename (dataset, category, stage, deciever model, supervisor model, timestamp),"
             f"but found {len(atoms)}. Atoms are underscore delimited."
         )
 
     return tuple(atoms)
 
 
-def next_filename_in_chain(filename: str) -> str:
+def next_filename_in_chain(filename: str, deciever_model: T.Optional[str] = None, supervisor_model: T.Optional[str] = None) -> str:
     """
     Returns the full filename of the next stage of the qa, qae, qaev, qaeve chain.
 
@@ -154,12 +166,29 @@ def next_filename_in_chain(filename: str) -> str:
 
     next_stage_dict = {"qa": "qae", "qae": "qaev", "qaev": "qaeve"}
 
-    dataset, category, stage, timestamp = atoms_from_filename(filename)
+    # In states qae and qaev, we overwrite the model name with the model name that was passed into the function
+    # In all other cases, we grab the same model used at before
+    # If we're at a model that hasn't been specified, it should be named 'anyModel'.
+    stage = atoms_from_filename(filename)[2]
+    if stage == "qa":
+        dataset, category, stage, _, supervisor_model_name, timestamp = atoms_from_filename(filename)
+        if deciever_model is None:
+            raise ValueError("Deciever model must be specified when going from qa to qae")
+        deceiver_model_name = deciever_model
+    elif stage == "qae":
+        dataset, category, stage, deceiver_model_name, _, timestamp = atoms_from_filename(filename)
+        if supervisor_model is None:
+            raise ValueError("Supervisor model must be specified when going from qae to qaev")
+        supervisor_model_name = supervisor_model
+    else:
+        dataset, category, stage, deceiver_model_name, supervisor_model_name, timestamp = atoms_from_filename(filename)
+
+    
 
     if stage not in next_stage_dict:
         raise ValueError(f"Stage not recognized: {stage}. Known stages are {next_stage_dict.keys()}. Note that qaeve is the final stage and cannot be chained further.")
 
     next_stage = next_stage_dict[stage]
 
-    return filename_from_atoms(dataset, category, next_stage, timestamp)
+    return filename_from_atoms(dataset, category, next_stage, deceiver_model_name, supervisor_model_name, timestamp)
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -6,12 +6,17 @@ import lib.utils as utils
 
 def test_filename_from_atoms():
     # Test standard case
-    expected_filename = "mmlu_econometrics_qae_12345.json"
-    filename = utils.filename_from_atoms("mmlu", "econometrics", "qae", "12345")
+    expected_filename = "mmlu_econometrics_qae_model1_model2_12345.json"
+    filename = utils.filename_from_atoms("mmlu", "econometrics", "qae", "model1", "model2", "12345")
+    assert filename == expected_filename
+
+    # Test case with no supervisor specified
+    expected_filename = "mmlu_econometrics_qae_model1_anyModel_12345.json"
+    filename = utils.filename_from_atoms("mmlu", "econometrics", "qae", timestamp="12345", deciever_model="model1")
     assert filename == expected_filename
 
     # Test the timestamp has the right length (e.g., "2023-11-20-07-27-05-100667")
-    timestamped_filename = utils.filename_from_atoms("mmlu", "econometrics", "qae")
+    timestamped_filename = utils.filename_from_atoms("mmlu", "econometrics", "qae", "model1", "model2")
     timestamp = timestamped_filename.split(".json")[0].split("_")[-1]
     assert len(timestamp) == 26
 
@@ -26,44 +31,46 @@ def test_atoms_from_filename():
 
     # Test error on invalid number of atoms
     try:
-        utils.atoms_from_filename("a_b_c.json")
-        assert False, "Failed to throw error on invalid number of atoms."
-    except ValueError:
-        pass
-
-    try:
         utils.atoms_from_filename("a_b_c_d_e.json")
         assert False, "Failed to throw error on invalid number of atoms."
     except ValueError:
         pass
 
+    try:
+        utils.atoms_from_filename("a_b_c_d_e_f_g.json")
+        assert False, "Failed to throw error on invalid number of atoms."
+    except ValueError:
+        pass
+
     # Test standard case
-    dataset, category, stage, timestamp = utils.atoms_from_filename("a_b_c_d.json")
+    dataset, category, stage, deceiver_model, supervisor_model, timestamp = utils.atoms_from_filename("a_b_c_d_e_f.json")
     assert dataset == "a"
     assert category == "b"
     assert stage == "c"
-    assert timestamp == "d"
+    assert deceiver_model == "d"
+    assert supervisor_model == "e"
+    assert timestamp == "f"
 
 
 def test_next_filename_in_chain():
     # Test error if stage not in chain
     try:
-        utils.next_filename_in_chain("mmlu_econometrics_quack_12345.json")
+        utils.next_filename_in_chain("mmlu_econometrics_quack_model1_model2_12345.json")
         assert False, "Failed to throw error on incorrect stage 'quack'"
     except ValueError:
         pass
 
     # Test error if stage is last stage
     try:
-        utils.next_filename_in_chain("mmlu_econometrics_qaeve_12345.json")
+        utils.next_filename_in_chain("mmlu_econometrics_qaeve_model1_model2_12345.json")
         assert False, "Failed to throw error on final stage 'quave'"
     except ValueError:
         pass
 
     # Try standard case
-    filename = "mmlu_econometrics_qae_2023-11-20-07-27-05-100667.json"
-    expected_next = "mmlu_econometrics_qaev_2023-11-20-07-27-05-100667.json"
-    next_filename = utils.next_filename_in_chain(filename)
+    filename = "mmlu_econometrics_qae_model1_anyModel_2023-11-20-07-27-05-100667.json"
+    expected_next = "mmlu_econometrics_qaev_model1_model2_2023-11-20-07-27-05-100667.json"
+    next_filename = utils.next_filename_in_chain(filename, supervisor_model="model2")
     assert next_filename == expected_next
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,74 @@
+"""
+Test the utility functions in utils.py.
+"""
+
+import lib.utils as utils
+
+def test_filename_from_atoms():
+    # Test standard case
+    expected_filename = "mmlu_econometrics_qae_12345.json"
+    filename = utils.filename_from_atoms("mmlu", "econometrics", "qae", "12345")
+    assert filename == expected_filename
+
+    # Test the timestamp has the right length (e.g., "2023-11-20-07-27-05-100667")
+    timestamped_filename = utils.filename_from_atoms("mmlu", "econometrics", "qae")
+    timestamp = timestamped_filename.split(".json")[0].split("_")[-1]
+    assert len(timestamp) == 26
+
+
+def test_atoms_from_filename():
+    # Test error on non-JSON
+    try:
+        utils.atoms_from_filename("something.txt")
+        assert False, "Failed to throw error on non-JSON file extension."
+    except ValueError:
+        pass
+
+    # Test error on invalid number of atoms
+    try:
+        utils.atoms_from_filename("a_b_c.json")
+        assert False, "Failed to throw error on invalid number of atoms."
+    except ValueError:
+        pass
+
+    try:
+        utils.atoms_from_filename("a_b_c_d_e.json")
+        assert False, "Failed to throw error on invalid number of atoms."
+    except ValueError:
+        pass
+
+    # Test standard case
+    dataset, category, stage, timestamp = utils.atoms_from_filename("a_b_c_d.json")
+    assert dataset == "a"
+    assert category == "b"
+    assert stage == "c"
+    assert timestamp == "d"
+
+
+def test_next_filename_in_chain():
+    # Test error if stage not in chain
+    try:
+        utils.next_filename_in_chain("mmlu_econometrics_quack_12345.json")
+        assert False, "Failed to throw error on incorrect stage 'quack'"
+    except ValueError:
+        pass
+
+    # Test error if stage is last stage
+    try:
+        utils.next_filename_in_chain("mmlu_econometrics_qaeve_12345.json")
+        assert False, "Failed to throw error on final stage 'quave'"
+    except ValueError:
+        pass
+
+    # Try standard case
+    filename = "mmlu_econometrics_qae_2023-11-20-07-27-05-100667.json"
+    expected_next = "mmlu_econometrics_qaev_2023-11-20-07-27-05-100667.json"
+    next_filename = utils.next_filename_in_chain(filename)
+    assert next_filename == expected_next
+
+
+if __name__ == "__main__":
+    test_filename_from_atoms()
+    test_atoms_from_filename()
+    test_next_filename_in_chain()
+


### PR DESCRIPTION
Dataset filenames are stored as atoms (dataset, category, stage, timestamp) delimited by underscores. The format is easily extensible later if more information becomes relevant for filenames.

Example: "mmlu_econometrics_qae_2023-11-20-07-27-05-100667.json".

This PR introduces functions to convert the relevant atoms into a filename, to convert a filename back into its atoms, and to iterate one step forward in the chain of qa, qae, qaev, qaeve.

Test cases all pass on my local device.