### PR TITLE
Feature/add metadata updates to chain

### DIFF
--- a/config.py
+++ b/config.py
@@ -99,7 +99,7 @@ CoT_base_config = {
 ###############################################
 
 deceiver_base_config = {
-    "prompt": deceiver_base_prompt,
+    "explanation_prompt": deceiver_base_prompt,
     # Other things?
 }
 

--- a/lib/chain.py
+++ b/lib/chain.py
@@ -90,7 +90,7 @@ class Deceiver(DatasetLLM):
 
         updated_metadata["deceiver_llm"] = self.llm.name
         updated_metadata["explanation_prompt"] = deceiver_base_config["explanation_prompt"]
-        updated_metadata["deciever_evalaution_prompt"] = evaluator_base_config["prompt"]
+        updated_metadata["deciever_evaluation_prompt"] = evaluator_base_config["prompt"]
 
         return updated_metadata
 

--- a/lib/chain.py
+++ b/lib/chain.py
@@ -81,7 +81,7 @@ class Deceiver(DatasetLLM):
         """
         Update the metadata to describe what is happening during the stage.
 
-        Specifically, we want to mension the deceiver llm, the explanation
+        Specifically, we want to mention the deceiver llm, the explanation
         prompt, and the deceiver evaluation prompt
         """
 
@@ -121,7 +121,7 @@ class Supervisor(DatasetLLM):
         """
         Update the metadata to describe what is happening during the stage.
 
-        Specifically, we want to mension the supervisor llm and verdict prompt,
+        Specifically, we want to mention the supervisor llm and verdict prompt,
 
         """
 
@@ -159,7 +159,7 @@ class Evaluator(DatasetLLM):
         """
         Update the metadata to describe what is happening during the stage.
 
-        Specifically, we want to mension the evaluator llm and evaluator prompt,
+        Specifically, we want to mention the evaluator llm and evaluator prompt,
 
         """
 

--- a/lib/chain.py
+++ b/lib/chain.py
@@ -67,7 +67,7 @@ class Deceiver(DatasetLLM):
             Answer = qa["answer"],
         )
 
-        evalaution_prompt = evaluator_base_config["prompt"].format(
+        evaluation_prompt = evaluator_base_config["prompt"].format(
             Question = qa["question"],
             Answer = qa["answer"],
         )

--- a/test/data/qa_testsmall_2023-11-08_09_07_32.json
+++ b/test/data/qa_testsmall_2023-11-08_09_07_32.json
@@ -1,5 +1,5 @@
 { 
-	"meta":{
+	"metadata":{
 		"dataset": "testsmall"
 	},
 	


### PR DESCRIPTION
Added the ability to edit the metadata for each iteration of the chain. Mostly just added the llm names and prompts. \

Also found one small bug in the chain code, one small bug in the configuration keys for the deceiver config, and edited the test file to be of the proper format. This is all in preparation for the full pipeline test.