### PR TITLE
Add protobuf and peft packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 accelerate==0.22.0
 bitsandbytes==0.41.1
 openai==0.27.9
+peft==0.6.2
+protobuf==4.25.1
 sentence-transformers==2.2.2
 sentencepiece==0.1.99
 tiktoken==0.4.0


### PR DESCRIPTION
Very small PR to add protobuf and peft packages to the requirements. These are needed to load Llama2. Peft will enable finetuning and protobuf is required to run on the GPUs which are used at CAIS.